### PR TITLE
Adds escaping for underscores in paths and param names

### DIFF
--- a/lib/grape_doc/formatters/markdown_formatter.rb
+++ b/lib/grape_doc/formatters/markdown_formatter.rb
@@ -4,12 +4,12 @@ module GrapeDoc
       title = "### #{resource.resource_name}\n"
       
       documents = resource.documents.map do |document|
-        path = "#### #{document.http_method} #{document.path}\n\n"
+        path = "#### #{document.http_method} #{escape(document.path)}\n\n"
         description = "#{document.description}\n\n"
         
         parameters = document.params.map do |parameter| 
           next if parameter.field.nil? or parameter.field.empty?
-          param = " - #{parameter.field}"
+          param = " - #{escape(parameter.field)}"
           param += " (#{parameter.field_type})" if parameter.field_type
           param += " (*required*)" if parameter.required
           param += " : #{parameter.description} " if parameter.description
@@ -24,6 +24,12 @@ module GrapeDoc
       end.join
       return "" if documents.nil? or documents.empty?
       "#{title}\n\n\n#{documents}\n"
+    end
+
+    private
+
+    def escape(str)
+      str.gsub('_', '\_')
     end
   end
 end

--- a/spec/markdown_formatter_spec.rb
+++ b/spec/markdown_formatter_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe 'GrapeDoc::MarkdownFormatter' do
+  let(:formatter) { GrapeDoc::MarkdownFormatter.new }
+
+  let(:resource) do
+    instance_double('GrapeDoc::APIResource',
+      resource_name: 'MightyNeatResource',
+      documents: [document])
+  end
+
+  let(:param) do
+    instance_double('GrapeDoc::APIParameter',
+      field: 'radical_value',
+      field_type: 'String',
+      required: true,
+      description: 'This value is so very rad.  I bet you wish you were too.',
+      sample_value: 'raddish')
+  end
+
+  let(:document) do
+    instance_double('GrapeDoc::APIDocument',
+      params: [param],
+      http_method: 'POST',
+      path: '/a_twisty_path',
+      description: 'Nobody really knows what this does.'\
+        'Nobody but Zorp that is.')
+  end
+
+  subject(:markdown) { formatter.generate_resource_doc(resource) }
+
+  it 'escapes underscores in paths' do
+    expect(markdown).not_to match /\/a_twisty_path/
+    expect(markdown).to match /\/a\\_twisty\\_path/
+  end
+
+  it 'escapes underscores in param names' do
+    expect(markdown).not_to match /radical_value/
+    expect(markdown).to match /radical\\_value/
+  end
+end


### PR DESCRIPTION
This might be a little naive.  I can implement with something a little more robust than regex if need be but I'm thinking this might be good enough for these particular fields.