### PR TITLE
escape square brackets

### DIFF
--- a/lib/grape_doc/formatters/markdown_formatter.rb
+++ b/lib/grape_doc/formatters/markdown_formatter.rb
@@ -29,7 +29,9 @@ module GrapeDoc
     private
 
     def escape(str)
-      str.gsub('_', '\_')
+      str.gsub('_', '\_').
+          gsub('[', '\[').
+          gsub(']', '\]')
     end
   end
 end

--- a/spec/markdown_formatter_spec.rb
+++ b/spec/markdown_formatter_spec.rb
@@ -11,7 +11,7 @@ describe 'GrapeDoc::MarkdownFormatter' do
 
   let(:param) do
     instance_double('GrapeDoc::APIParameter',
-      field: 'radical_value',
+      field: 'radical_value[radical_nested]',
       field_type: 'String',
       required: true,
       description: 'This value is so very rad.  I bet you wish you were too.',
@@ -34,8 +34,8 @@ describe 'GrapeDoc::MarkdownFormatter' do
     expect(markdown).to match /\/a\\_twisty\\_path/
   end
 
-  it 'escapes underscores in param names' do
-    expect(markdown).not_to match /radical_value/
-    expect(markdown).to match /radical\\_value/
+  it 'escapes underscores anb square bracket in param names' do
+    expect(markdown).not_to match /radical_value\[radical_nested\]/
+    expect(markdown).to match /radical\\_value\\\[radical\\_nested\\\]/
   end
 end


### PR DESCRIPTION
the formatter should escape square brackets when params are nested
```ruby
params do
  requires :radical_value, type: Hash do
    requires :radical_nested, 
              type: String, 
              desc: 'This value is so very rad.  I bet you wish you were too.'
  end
end
```
radical_value[radical_nested]